### PR TITLE
[BUG] Improper replacement line to get favicon relay file

### DIFF
--- a/src/components/RelayFavicon.tsx
+++ b/src/components/RelayFavicon.tsx
@@ -3,7 +3,6 @@ import { PhoneIcon } from "@chakra-ui/icons";
 
 export function RelayFavicon({ url, children, ...rest }) {
   const domain = url
-    .replace("wss://relay.", "https://")
     .replace("wss://", "https://")
     .replace("ws://", "http://")
     .replace(/\/$/, "");


### PR DESCRIPTION
favicon.ico file is normally stored inside of the same relay storage and normally we use a subdomain to redirect to our relays, in concrete with the word "relay"

Replace the subdomain "relay" `"wss://relay."` with `"https://"` for causes that do not obtain the real location of the favicon.ico file on the relay storage, and the link return a `404 error "file not found"`

Some reason to delete the "relay" subdomain word to obtain the favicon.ico file of the relay?

Delete this line would fix the error

ref before the fix:

![Captura322456453534654457](https://github.com/twofaktor/relays/assets/89636253/6f543e85-9b25-4b8a-9a1d-18fd3e0b95b0)

ref after the fix:

![photo_2023-08-08_16-25-46](https://github.com/twofaktor/relays/assets/89636253/499c920a-f629-43f6-ae1a-8fbb5ea0287e)

PS:
habla.news, nostrrr.com, and relays.vercel.app services affected

other references: https://github.com/vitorpamplona/amethyst/blob/89266bc76f1565e20fa465f46507c626d9107d91/app/src/main/java/com/vitorpamplona/amethyst/ui/note/RelayListRow.kt#L110