### PR TITLE
make relay urls a first-class citizen, replacing nrelay codes

### DIFF
--- a/src/components/RelayLink.tsx
+++ b/src/components/RelayLink.tsx
@@ -7,11 +7,10 @@ import {
   CardHeader,
   CardBody,
   HStack,
-  Box,
 } from "@chakra-ui/react";
-import { nip19 } from "nostr-tools";
 
 import { RelayFavicon } from "./RelayFavicon";
+import { encodeRelayURL } from "../utils";
 
 const RelaySummary = dynamic(
   () => import("./RelaySummary").then((mod) => mod.RelaySummary),
@@ -22,7 +21,7 @@ export function RelayLink({ url, info }) {
   return (
     <Card>
       <CardHeader>
-        <Link key={url} href={`/relay/${nip19.nrelayEncode(url)}`}>
+        <Link key={url} href={`/relay/${encodeRelayURL(url)}`}>
           <HStack spacing={2}>
             <RelayFavicon url={url} />
             <Text fontSize="lg">{url}</Text>

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,6 +1,5 @@
 import { useState } from "react";
 import Head from "next/head";
-import Link from "next/link";
 import { useRouter } from "next/router";
 
 import {
@@ -11,7 +10,6 @@ import {
   InputRightElement,
 } from "@chakra-ui/react";
 import { PhoneIcon } from "@chakra-ui/icons";
-import { nip19 } from "nostr-tools";
 
 import { getRelays } from "../nostr";
 import { Layout } from "../components/Layout";
@@ -22,8 +20,8 @@ const Index = ({ relays }) => {
   const router = useRouter();
   const [relay, setRelay] = useState("");
 
-  function goToRelay(url) {
-    router.push(`/relay/${nip19.nrelayEncode(url)}`);
+  function goToRelay(url: string) {
+    router.push(`/relay/${encodeRelayURL(url)}`);
   }
 
   function randomRelay() {

--- a/src/pages/relay/[nrelay].tsx
+++ b/src/pages/relay/[nrelay].tsx
@@ -18,19 +18,27 @@ const Feed = dynamic(
 
 const Relay = ({}) => {
   const router = useRouter();
-  const { nrelay } = router.query;
+  const { nrelay: nrelayOrUrl } = router.query;
   const url = useMemo(() => {
-    try {
-      if (nrelay) {
-        const decoded = nip19.decode(nrelay);
+    if (!nrelayOrUrl) return;
+
+    if (typeof nrelayOrUrl === "string") {
+      try {
+        const decoded = nip19.decode(nrelayOrUrl);
         if (decoded.type === "nrelay") {
           return decoded.data;
         }
+      } catch (error) {
+        /***/
       }
-    } catch (error) {
-      console.error("Couldn't decode nrelay");
+
+      let url = decodeURIComponent(nrelayOrUrl);
+      if (!url.startsWith("ws")) url = "wss://" + url;
+      if (url) return url;
     }
-  }, [nrelay]);
+
+    console.error("Couldn't decode relay url", nrelayOrUrl);
+  }, [nrelayOrUrl]);
 
   // todo: error page
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,0 +1,7 @@
+export function encodeRelayURL(url: string): string {
+  url = url.trim();
+  if (url.startsWith("wss://")) {
+    url = url.slice(6);
+  }
+  return encodeURIComponent(url);
+}


### PR DESCRIPTION
nrelay codes are still decoded, but I think using raw urls is better for everybody since they are readable.

![2023-11-23-163225_532x460_scrot](https://github.com/verbiricha/relays/assets/1653275/6e3eccd0-d7b7-49d3-8ce0-c4cc6c5af59b)

they can also include path segments and schemes (everything is assumed to be `wss://` unless specified), in this case they will be URI-encoded (i.e. a `/` is translated into `%2f` basically).